### PR TITLE
Use block arguments instead of Kernel#proc

### DIFF
--- a/lib/emfrp/compile/c/codegen_context.rb
+++ b/lib/emfrp/compile/c/codegen_context.rb
@@ -147,7 +147,7 @@ module Emfrp
 
     def define_func(type_str, name_str, params, accessor=:static, with_proto=true, &block)
       elements = []
-      proc.call(elements)
+      block.call(elements)
       case accessor
       when :none then deco = ""
       when :static then deco = "static "
@@ -176,9 +176,9 @@ module Emfrp
       @init_stmts << stmt
     end
 
-    def define_struct(kind_str, name_str, var_name_str)
+    def define_struct(kind_str, name_str, var_name_str, &block)
       elements = []
-      proc.call(elements)
+      block.call(elements)
       x = Block.new("#{kind_str} #{name_str}{", elements, "}#{var_name_str};")
       if name_str
         @structs << x


### PR DESCRIPTION
This commit is due to https://docs.ruby-lang.org/en/3.0.0/doc/NEWS-2_7_0.html#label-proc-2Flambda+without+block+is+deprecated